### PR TITLE
Changed utf8 to utf-8 to have valid HTML

### DIFF
--- a/admin/acl.php
+++ b/admin/acl.php
@@ -63,7 +63,7 @@ if(userBelongToGroup($_SESSION['username'], 'ADMINISTRATORS')){
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="../css/main.css" media="screen" type="text/css" />
     <link rel="stylesheet" href="../css/admin.css" media="screen" type="text/css" />

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -58,7 +58,7 @@ if(userBelongToGroup($_SESSION['username'], 'ADMINISTRATORS')){
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="../css/main.css" media="screen" type="text/css" />
     <link rel="stylesheet" href="../css/admin.css" media="screen" type="text/css" />

--- a/admin/index.php
+++ b/admin/index.php
@@ -31,7 +31,7 @@ if(userBelongToGroup($_SESSION['username'], 'ADMINISTRATORS')){
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="../css/main.css" media="screen" type="text/css" />
     <link rel="stylesheet" href="../css/admin.css" media="screen" type="text/css" />

--- a/admin/init_admin.php
+++ b/admin/init_admin.php
@@ -41,7 +41,7 @@
 
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="../css/main.css" type="text/css" />
     <link rel="stylesheet" href="../css/admin.css" type="text/css" />

--- a/admin/login.php
+++ b/admin/login.php
@@ -35,7 +35,7 @@
 
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="../css/main.css" type="text/css" />
     <link rel="stylesheet" href="../css/admin.css" type="text/css" />

--- a/admin/statistics.php
+++ b/admin/statistics.php
@@ -15,7 +15,7 @@ if(strlen(trim($cbmpTitlePage))==0){
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="../css/main.css" media="screen" type="text/css" />
     <link rel="stylesheet" href="../css/admin.css" media="screen" type="text/css" />

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@ if(strlen(trim($cbmpTitlePage))==0){
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="lib/ol3/css/ol.css" type="text/css">
     <link rel="stylesheet" href="css/main.css" type="text/css">

--- a/project.html
+++ b/project.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="css/main.css" type="text/css" />
 


### PR DESCRIPTION
Fixed meta charset to avoid "Bad value utf8 for attribute charset on element meta: utf8 is not a preferred encoding name. The preferred label for this encoding is utf-8." in W3 HTML validator
